### PR TITLE
移除虾米音乐

### DIFF
--- a/Sora/Enumeration/EventParamsType/MusicShareType.cs
+++ b/Sora/Enumeration/EventParamsType/MusicShareType.cs
@@ -16,11 +16,6 @@ namespace Sora.Enumeration.EventParamsType
         /// QQ 音乐
         /// </summary>
         [Description("qq")]
-        QQMusic,
-        /// <summary>
-        /// 虾米音乐
-        /// </summary>
-        [Description("xm")]
-        Xiami
+        QQMusic
     }
 }


### PR DESCRIPTION
onebot-mirai  
![image](https://user-images.githubusercontent.com/11478651/106359482-0ce70e00-634e-11eb-94dd-4b86dd4b8521.png)
go-cqhttp  
https://github.com/Mrs4s/go-cqhttp/blob/master/coolq/cqcode.go#L692  
均不支持虾米音乐，因此移除